### PR TITLE
Bab 403 complete kv store and the kv store bridge with documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ KVStore is a simple, un-permissioned key-value storage and retrieval system that
 import { get, set } from 'babbage-kvstore'
 
 // Set a value
-set({'name', 'Bob')
+set('name', 'Bob')
 
 // Retrieve a value
 get('name') // => 'Bob'

--- a/kvstore.js
+++ b/kvstore.js
@@ -2,6 +2,12 @@ const parapet = require('parapet-js')
 const SDK = require('@babbage/sdk')
 const pushdrop = require('pushdrop')
 
+const defaultConfig = {
+  resolvers: undefined,
+  protocolID: [0, 'kvstore'],
+  tokenAmount: 1000
+}
+
 const KVSTORE_PROTOCOL_ADDRESS = '13vGYFqfJsFYaA3mheYgPKuishLG7sYDaE'
 
 /**
@@ -11,10 +17,10 @@ const KVSTORE_PROTOCOL_ADDRESS = '13vGYFqfJsFYaA3mheYgPKuishLG7sYDaE'
  *
  * @returns {Promise<String>} The value from the store
  */
-const get = async (key, defaultValue=undefined) => {
+const get = async (key, defaultValue=undefined, config=defaultConfig) => {
   const protectedKey = await SDK.createHmac({
     data: key,
-    protocolID: [0, 'kvstore'],
+    protocolID: config.protocolID,
     keyID: key
   })
   const result = await parapet({
@@ -32,7 +38,7 @@ const get = async (key, defaultValue=undefined) => {
         }
       }
     },
-    resolvers: ['http://localhost:3103']
+    resolvers: config.resolvers
   })
   if (result.length === 0) {
     if (defaultValue !== undefined) {
@@ -51,10 +57,10 @@ const get = async (key, defaultValue=undefined) => {
  *
  * @returns {Promise} Promise that resolves when the value has been stored
  */
-const set = async (key, value) => {
+const set = async (key, value, config=defaultConfig) => {
   const protectedKey = await SDK.createHmac({
     data: Uint8Array.from(Buffer.from(key)),
-    protocolID: [0, 'kvstore'],
+    protocolID: config.protocolID,
     keyID: key
   })
 
@@ -73,7 +79,7 @@ const set = async (key, value) => {
         }
       }
     },
-    resolvers: ['http://localhost:3103']
+    resolvers: config.resolvers
   })
 
   if (existing_tokens.length > 0 && existing_tokens[0].value != value) {
@@ -83,7 +89,7 @@ const set = async (key, value) => {
       outputIndex: kvstoreToken.token.outputIndex,
       lockingScript: kvstoreToken.token.lockingScript,
       outputAmount: kvstoreToken.token.outputAmount,
-      protocolID: [0, 'kvstore'],
+      protocolID: config.protocolID,
       keyID: key
     })
 
@@ -116,14 +122,14 @@ const set = async (key, value) => {
     await SDK.createAction({
       description: `Set a value for ${key}`,
       outputs: [{
-        satoshis: 1000,
+        satoshis: config.tokenAmount,
         script: await pushdrop.create({
           fields: [
             KVSTORE_PROTOCOL_ADDRESS,
             Buffer.from(protectedKey),
             value
           ],
-          protocolID: [0, 'kvstore'],
+          protocolID: config.protocolID,
           keyID: key
         })
       }],
@@ -140,10 +146,10 @@ const set = async (key, value) => {
  *
  * @returns {Promise} Promise that resolves when the value has been deleted
  */
-const remove = async (key) => {
+const remove = async (key, config=defaultConfig) => {
   const protectedKey = await SDK.createHmac({
     data: Uint8Array.from(Buffer.from(key)),
-    protocolID: [0, 'kvstore'],
+    protocolID: config.protocolID,
     keyID: key
   })
 
@@ -162,7 +168,7 @@ const remove = async (key) => {
         }
       }
     },
-    resolvers: ['http://localhost:3103']
+    resolvers: config.resolvers
   })
 
   if (existing_tokens.length > 0) {
@@ -172,7 +178,7 @@ const remove = async (key) => {
       outputIndex: kvstoreToken.token.outputIndex,
       lockingScript: kvstoreToken.token.lockingScript,
       outputAmount: kvstoreToken.token.outputAmount,
-      protocolID: [0, 'kvstore'],
+      protocolID: config.protocolID,
       keyID: key
     })
 

--- a/kvstore.js
+++ b/kvstore.js
@@ -78,8 +78,6 @@ const set = async (key, value) => {
 
   if (existing_tokens.length > 0 && existing_tokens[0].value != value) {
     const kvstoreToken = existing_tokens[0]
-    console.log(kvstoreToken)
-    debugger
     const unlockingScript = await pushdrop.redeem({
       prevTxId: kvstoreToken.token.txid,
       outputIndex: kvstoreToken.token.outputIndex,
@@ -118,7 +116,7 @@ const set = async (key, value) => {
     await SDK.createAction({
       description: `Set a value for ${key}`,
       outputs: [{
-        satoshis: 500,
+        satoshis: 1000,
         script: await pushdrop.create({
           fields: [
             KVSTORE_PROTOCOL_ADDRESS,
@@ -134,6 +132,64 @@ const set = async (key, value) => {
   }
 }
 
-// TODO: delete
+/**
+ * Deletes a value from the store.
+ *
+ * @param {String} key The key for the value to set
+ * @param {String} value The value to store
+ *
+ * @returns {Promise} Promise that resolves when the value has been deleted
+ */
+const remove = async (key) => {
+  const protectedKey = await SDK.createHmac({
+    data: Uint8Array.from(Buffer.from(key)),
+    protocolID: [0, 'kvstore'],
+    keyID: key
+  })
 
-module.exports = { get, set }
+  const existing_tokens = await parapet({
+    bridge: KVSTORE_PROTOCOL_ADDRESS,
+    request: {
+      type: 'json-query',
+      query: {
+        v: 3,
+        q: {
+          collection: 'kvstore',
+          find: {
+            protectedKey: Buffer.from(protectedKey).toString('base64')
+          },
+          limit: 1
+        }
+      }
+    },
+    resolvers: ['http://localhost:3103']
+  })
+
+  if (existing_tokens.length > 0) {
+    const kvstoreToken = existing_tokens[0]
+    const unlockingScript = await pushdrop.redeem({
+      prevTxId: kvstoreToken.token.txid,
+      outputIndex: kvstoreToken.token.outputIndex,
+      lockingScript: kvstoreToken.token.lockingScript,
+      outputAmount: kvstoreToken.token.outputAmount,
+      protocolID: [0, 'kvstore'],
+      keyID: key
+    })
+
+    await SDK.createAction({
+      description: `Delete the value for ${key}`,
+      inputs: {
+        [kvstoreToken.token.txid]: {
+          ...kvstoreToken.token,
+          outputsToRedeem: [{
+            index: kvstoreToken.token.outputIndex,
+            unlockingScript
+          }]
+        }
+      },
+      bridges: [KVSTORE_PROTOCOL_ADDRESS]
+    })
+  }
+}
+
+module.exports = { get, set, remove }

--- a/kvstore.js
+++ b/kvstore.js
@@ -2,7 +2,7 @@ const parapet = require('parapet-js')
 const SDK = require('@babbage/sdk')
 const pushdrop = require('pushdrop')
 
-const KVSTORE_PROTOCOL_ADDRESS = 'KVStore'
+const KVSTORE_PROTOCOL_ADDRESS = '13vGYFqfJsFYaA3mheYgPKuishLG7sYDaE'
 
 /**
  * Gets a value from the store.
@@ -11,7 +11,7 @@ const KVSTORE_PROTOCOL_ADDRESS = 'KVStore'
  *
  * @returns {Promise<String>} The value from the store
  */
-const get = async key => {
+const get = async (key, defaultValue=undefined) => {
   const protectedKey = await SDK.createHmac({
     data: key,
     protocolID: [0, 'kvstore'],
@@ -26,14 +26,18 @@ const get = async key => {
         q: {
           collection: 'kvstore',
           find: {
-            _id: Buffer.from(protectedKey).toString('hex')
+            protectedKey: Buffer.from(protectedKey).toString('base64')
           },
           limit: 1
         }
       }
-    }
+    },
+    resolvers: ['http://localhost:3103']
   })
   if (result.length === 0) {
+    if (defaultValue !== undefined) {
+      return defaultValue
+    }
     return undefined
   }
   return result[0].value
@@ -47,33 +51,87 @@ const get = async key => {
  *
  * @returns {Promise} Promise that resolves when the value has been stored
  */
-const set = async ({ key, value }) => {
+const set = async (key, value) => {
   const protectedKey = await SDK.createHmac({
-    data: key,
+    data: Uint8Array.from(Buffer.from(key)),
     protocolID: [0, 'kvstore'],
     keyID: key
   })
 
-  // TODO: Search for any existing token with this protected key
-
-  // TODO: If an existing token is found, append to that token
-
-  await SDK.createAction({
-    description: `Set a value for ${key}`,
-    outputs: [{
-      satoshis: 500,
-      script: await pushdrop.create({
-        fields: [
-          KVSTORE_PROTOCOL_ADDRESS,
-          Buffer.from(protectedKey),
-          value
-        ],
-        protocolID: [0, 'kvstore'],
-        keyID: key
-      })
-    }],
-    bridges: [KVSTORE_PROTOCOL_ADDRESS]
+  const existing_tokens = await parapet({
+    bridge: KVSTORE_PROTOCOL_ADDRESS,
+    request: {
+      type: 'json-query',
+      query: {
+        v: 3,
+        q: {
+          collection: 'kvstore',
+          find: {
+            protectedKey: Buffer.from(protectedKey).toString('base64')
+          },
+          limit: 1
+        }
+      }
+    },
+    resolvers: ['http://localhost:3103']
   })
+
+  if (existing_tokens.length > 0 && existing_tokens[0].value != value) {
+    const kvstoreToken = existing_tokens[0]
+    console.log(kvstoreToken)
+    debugger
+    const unlockingScript = await pushdrop.redeem({
+      prevTxId: kvstoreToken.token.txid,
+      outputIndex: kvstoreToken.token.outputIndex,
+      lockingScript: kvstoreToken.token.lockingScript,
+      outputAmount: kvstoreToken.token.outputAmount,
+      protocolID: [0, 'kvstore'],
+      keyID: key
+    })
+
+    await SDK.createAction({
+      description: `Update the value for ${key}`,
+      inputs: {
+        [kvstoreToken.token.txid]: {
+          ...kvstoreToken.token,
+          outputsToRedeem: [{
+            index: kvstoreToken.token.outputIndex,
+            unlockingScript
+          }]
+        }
+      },
+      outputs: [{
+        satoshis: 500,
+        script: await pushdrop.create({
+          fields: [
+            KVSTORE_PROTOCOL_ADDRESS,
+            Buffer.from(protectedKey),
+            value
+          ],
+          protocolID: [0, 'kvstore'],
+          keyID: key
+        })
+      }],
+      bridges: [KVSTORE_PROTOCOL_ADDRESS]
+    })
+  } else {
+    await SDK.createAction({
+      description: `Set a value for ${key}`,
+      outputs: [{
+        satoshis: 500,
+        script: await pushdrop.create({
+          fields: [
+            KVSTORE_PROTOCOL_ADDRESS,
+            Buffer.from(protectedKey),
+            value
+          ],
+          protocolID: [0, 'kvstore'],
+          keyID: key
+        })
+      }],
+      bridges: [KVSTORE_PROTOCOL_ADDRESS]
+    })
+  }
 }
 
 // TODO: delete

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@babbage/sdk": "^0.4.5",
         "parapet-js": "^0.1.4",
-        "pushdrop": "^0.1.8"
+        "pushdrop": "^0.1.9"
       },
       "devDependencies": {
         "documentation": "^14.0.0",
@@ -7974,9 +7974,9 @@
       }
     },
     "node_modules/pushdrop": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/pushdrop/-/pushdrop-0.1.8.tgz",
-      "integrity": "sha512-UaRZu6DJRA+4oq1UlBHMHJhzkYC/0XGHnm9yUdi9UALm9X0SruVC8RFFum2l8DDmtYZu9rJNLYrP71usDcNi0w==",
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/pushdrop/-/pushdrop-0.1.9.tgz",
+      "integrity": "sha512-BcQbf0Rz5uw7KCUbEoanjWZUI6srJYpHrmvjcFyUkVTqHP3yPm9XV1GeCb4X9fxjsqS+uCm9P8GbceNav1fP+g==",
       "dependencies": {
         "@babbage/sdk": "^0.3.0",
         "babbage-bsv": "^0.1.0"
@@ -15379,9 +15379,9 @@
       "dev": true
     },
     "pushdrop": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/pushdrop/-/pushdrop-0.1.8.tgz",
-      "integrity": "sha512-UaRZu6DJRA+4oq1UlBHMHJhzkYC/0XGHnm9yUdi9UALm9X0SruVC8RFFum2l8DDmtYZu9rJNLYrP71usDcNi0w==",
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/pushdrop/-/pushdrop-0.1.9.tgz",
+      "integrity": "sha512-BcQbf0Rz5uw7KCUbEoanjWZUI6srJYpHrmvjcFyUkVTqHP3yPm9XV1GeCb4X9fxjsqS+uCm9P8GbceNav1fP+g==",
       "requires": {
         "@babbage/sdk": "^0.3.0",
         "babbage-bsv": "^0.1.0"

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@babbage/sdk": "^0.4.5",
     "parapet-js": "^0.1.4",
-    "pushdrop": "^0.1.8"
+    "pushdrop": "^0.1.9"
   },
   "devDependencies": {
     "documentation": "^14.0.0",


### PR DESCRIPTION
Completing KVStore and its bridge will highlight practical use-cases around tokenization and bridgeport

## Business / User Value
As a Babbage app developer, I want to create, read, update an delete generic values within a key-value store so that I can easily define things like configurations, preferences, logs and small data structures.

## Acceptance Criteria
The ticket will be completed when a Bridgeport bridge has been created which facilitates the functionality of the KVStore library. Further:
- [x] Calling `set` with a key which already exists should spend the previous rendition of the UTXO associated with the key, and create a new one
- [x] Calling `get` should retrieve the value associated with a key
- [x] Calling a new `delete` function (which takes key as its sole parameter (just like get does), should locate and spend the UTXO associated with the key, without creating a new one. Thereby, the token is removed from the bridge.